### PR TITLE
Add support for <sergey-link>

### DIFF
--- a/example/_imports/header.html
+++ b/example/_imports/header.html
@@ -6,9 +6,10 @@
     <nav class="center">
       <a href="/#quick-start">Quick start</a>
       <a href="/#get-started">Walkthrough</a>
-      <a href="/slots/">Slots</a>
-      <a href="/markdown/">Markdown</a>
-      <a href="/options/">Options</a>
+      <sergey-link to="/slots/">Slots</sergey-link>
+      <sergey-link to="/links/">Links</sergey-link>
+      <sergey-link to="/markdown/">Markdown</sergey-link>
+      <sergey-link to="/options/">Options</sergey-link>
       <a href="https://github.com/trys/sergey">GitHub</a>
     </nav>
     <sergey-slot />

--- a/example/_imports/links.md
+++ b/example/_imports/links.md
@@ -1,0 +1,69 @@
+## Why you might need links
+
+Let's take an example of a navigation template you might use on a site:
+
+```html
+<nav>
+  <a href="/">Home</a>
+  <a href="/about/">About</a>
+  <a href="/contact/">Contact</a>
+</nav>
+```
+
+If this template is saved as `_imports/navigation.html`, you can reuse the navigation on any page like so:
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Our lil' website</title>
+</head>
+<body>
+  <header>
+    <sergey-import src="navigation" />
+  </header>
+  <main>
+    <h1>Welcome!</h1>
+    <p>Our page content.</p>
+  </main>
+</body>
+</html>
+```
+
+So far, so good! However, on each page, we'd like this template to render a little differently. For example, on the homepage the navigation would render like so:
+
+```html
+<nav>
+  <a href="/" class="active" aria-current="page">Home</a>
+  <a href="/about/">About</a>
+  <a href="/contact/">Contact</a>
+</nav>
+```
+
+Whereas on the about page, it should render like this:
+
+```html
+<nav>
+  <a href="/">Home</a>
+  <a href="/about/" class="active" aria-current="page">About</a>
+  <a href="/contact/">Contact</a>
+</nav>
+```
+
+That's where `<sergey-link>` comes in!
+
+#### Change navigation links to `<sergey-link>`
+
+In the sample above, we can change our navigation template (`_imports/navigation.html`) to the following:
+
+```html
+<nav>
+  <sergey-link to="/">Home</sergey-link>
+  <sergey-link to="/about/">About</sergey-link>
+  <sergey-link to="/contact/">Contact</sergey-link>
+</nav>
+```
+
+Now when Sergey builds our site, it will add `class="active"` and `aria-current="page"` as appropriate on each page!

--- a/example/assets/css/style.css
+++ b/example/assets/css/style.css
@@ -152,6 +152,7 @@ pre {
 
 pre code {
   background: transparent;
+  white-space: inherit;
 }
 
 .content hr {

--- a/example/assets/css/style.css
+++ b/example/assets/css/style.css
@@ -69,6 +69,11 @@ a {
   color: inherit;
 }
 
+[aria-current] {
+  font-weight: 600;
+  text-decoration: none;
+}
+
 .center {
   text-align: center;
 }

--- a/example/links/index.html
+++ b/example/links/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <sergey-import src="head">
+    <sergey-template name="title">Links | Sergey | the little static site generator</sergey-template>
+  </sergey-import>
+</head>
+
+<body>
+  <sergey-import src="header">
+    <p>Links are a practical way to show your users where they are in your navigation. They're completely opt-in, so if you prefer to use classic <abbr title="HyperText Markup Language">HTML</abbr> links, go for it!</p>
+  </sergey-import>
+
+  <main class="insulate">
+    <div class="wrapper content">
+      <sergey-import src="links" as="markdown" />
+    </div>
+  </main>
+
+  <sergey-import src="footer" />
+</body>
+</html>

--- a/src/index.js
+++ b/src/index.js
@@ -26,6 +26,8 @@ const CONTENT = `${ROOT}${CONTENT_LOCAL}/`;
 const OUTPUT_LOCAL = getEnv('--output=', 'SERGEY_OUTPUT') || 'public';
 const OUTPUT = `${ROOT}${OUTPUT_LOCAL}/`;
 
+const ACTIVE_CLASS = getEnv('--active-class=', 'SERGEY_ACTIVE_CLASS') || 'active';
+
 const EXCLUDE = (getEnv('--exclude=', 'SERGEY_EXCLUDE') || '')
   .split(',')
   .map(x => x.trim())
@@ -53,7 +55,8 @@ const patterns = {
   complexDefaultSlots: /<sergey-slot>(.*?)<\/sergey-slot>/gms,
   simpleDefaultSlots: /<sergey-slot\s?\/>/gm,
   complexImports: /<sergey-import src="([a-zA-Z0-9-.\\\/]*)"(?:\sas="(.*?)")?>(.*?)<\/sergey-import>/gms,
-  simpleImports: /<sergey-import src="([a-zA-Z0-9-.\\\/]*)"(?:\sas="(.*?)")?\s?\/>/gm
+  simpleImports: /<sergey-import src="([a-zA-Z0-9-.\\\/]*)"(?:\sas="(.*?)")?\s?\/>/gm,
+  links: /<sergey-link to="([a-zA-Z0-9-.#?\\\/]*)">(.*?)<\/sergey-link>/gms
 };
 
 /**
@@ -183,11 +186,15 @@ const getKey = (key, ext = '.html', folder = '') => {
   return `${folder}${file}`;
 };
 const hasImports = x => x.includes('<sergey-import');
+const hasLinks = x => x.includes('<sergey-link');
 const primeExcludedFiles = name => {
   if (!excludedFolders.includes(name)) {
     excludedFolders.push(name);
   }
 };
+const cleanPath = (path) => path.replace('index.html', '').split('#')[0];
+const isCurrentPage = (ref, path) => path && cleanPath(path) === cleanPath(ref);
+const isParentPage = (ref, path) => path && cleanPath(path).startsWith(cleanPath(ref));
 
 /**
  * #business logic
@@ -315,6 +322,38 @@ const compileTemplate = (body, slots = { default: '' }) => {
   return body;
 };
 
+const compileLinks = (body, path) => {
+  let m;
+  let copy;
+
+  if (!hasLinks(body)) {
+    return body;
+  }
+
+  copy = body;
+  while ((m = patterns.links.exec(body)) !== null) {
+    if (m.index === patterns.links.lastIndex) {
+      patterns.links.lastIndex++;
+    }
+
+    let [find, to, content] = m;
+    let replace = '';
+
+    if (isCurrentPage(to, path)) {
+      replace = `<a href="${to}" class="${ACTIVE_CLASS}" aria-current="page">${content}</a>`;
+    } else if (isParentPage(to, path)) {
+      replace = `<a href="${to}" class="${ACTIVE_CLASS}">${content}</a>`;
+    } else {
+      replace = `<a href="${to}">${content}</a>`;
+    }
+
+    copy = copy.replace(find, replace);
+  }
+  body = copy;
+
+  return body;
+};
+
 const compileFolder = async (localFolder, localPublicFolder) => {
   const fullFolderPath = `${ROOT}${localFolder}`;
   const fullPublicPath = `${ROOT}${localPublicFolder}`;
@@ -337,10 +376,12 @@ const compileFolder = async (localFolder, localPublicFolder) => {
           .map(async localFilePath => {
             const fullFilePath = `${fullFolderPath}${localFilePath}`;
             const fullPublicFilePath = `${fullPublicPath}${localFilePath}`;
+            const fullLocalFilePath = `/${localFolder}${localFilePath}`;
 
             if (localFilePath.endsWith('.html')) {
               return readFile(fullFilePath)
                 .then(compileTemplate)
+                .then(body => compileLinks(body, fullLocalFilePath))
                 .then(body => writeFile(fullPublicFilePath, body));
             }
 
@@ -457,7 +498,9 @@ const sergeyRuntime = async () => {
 module.exports = {
   sergeyRuntime,
   compileTemplate,
+  compileLinks,
   primeImport,
   CONTENT,
-  IMPORTS
+  IMPORTS,
+  ACTIVE_CLASS
 };

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -1,4 +1,4 @@
-const { compileTemplate, primeImport, IMPORTS } = require('../src');
+const { compileTemplate, compileLinks, primeImport, IMPORTS, ACTIVE_CLASS } = require('../src');
 
 const wrapper = (x = '') => `<html>
   <body>
@@ -282,6 +282,164 @@ Content is **great**.`
     const output = compileTemplate(
       '<sergey-import src="about" as="markdown" />'
     );
+
+    expect(output).toBe(desiredOutput);
+  });
+
+  test('Multiline markdown with code block', () => {
+    primeImport(
+      testImport('code.md'),
+      `<sergey-import src="snippet" as="markdown" />`
+    );
+
+    primeImport(
+      testImport('snippet.md'),
+      `# Example code block
+
+\`\`\`html
+<article>
+  <sergey-import src="code" as="markdown" />
+</article>
+\`\`\`
+`
+    );
+    const desiredOutput = `<h1 id="example-code-block">Example code block</h1>
+<pre><code class="language-html">&lt;article&gt;
+  &lt;sergey-import src=&quot;code&quot; as=&quot;markdown&quot; /&gt;
+&lt;/article&gt;</code></pre>`;
+
+    const output = compileTemplate(
+      '<sergey-import src="code" as="markdown" />'
+    );
+
+    expect(output).toBe(desiredOutput);
+  });
+});
+
+describe('Link compilation', () => {
+  test('A link', () => {
+    const input = `<sergey-link to="/example/">Example Link</sergey-link>`;
+    const desiredOutput = `<a href="/example/">Example Link</a>`;
+    const output = compileLinks(input);
+
+    expect(output).toBe(desiredOutput);
+  });
+
+  test('Multiple links', () => {
+    const input = `
+      <sergey-link to="/example-1/">Example Link 1</sergey-link>
+      <sergey-link to="/example-2/">Example Link 2</sergey-link>
+      <sergey-link to="/example-3/">Example Link 3</sergey-link>
+      `;
+    const desiredOutput = `
+      <a href="/example-1/">Example Link 1</a>
+      <a href="/example-2/">Example Link 2</a>
+      <a href="/example-3/">Example Link 3</a>
+      `;
+    const output = compileLinks(input);
+
+    expect(output).toBe(desiredOutput);
+  });
+
+  test('A link to identical current path', () => {
+    const input = `<sergey-link to="/example/index.html">Example</sergey-link>`;
+    const path = '/example/index.html';
+
+    const desiredOutput = `<a href="/example/index.html" class="${ACTIVE_CLASS}" aria-current="page">Example</a>`;
+    const output = compileLinks(input, path);
+
+    expect(output).toBe(desiredOutput);
+  });
+
+  test('A link to start of current path', () => {
+    const input = `<sergey-link to="/example/">Example</sergey-link>`;
+    const path = '/example/index.html';
+
+    const desiredOutput = `<a href="/example/" class="${ACTIVE_CLASS}" aria-current="page">Example</a>`;
+    const output = compileLinks(input, path);
+
+    expect(output).toBe(desiredOutput);
+  });
+
+  test('A link to a parent path', () => {
+    const input = `<sergey-link to="/example/">Example</sergey-link>`;
+    const path = '/example/foo/index.html';
+
+    const desiredOutput = `<a href="/example/" class="${ACTIVE_CLASS}">Example</a>`;
+    const output = compileLinks(input, path);
+
+    expect(output).toBe(desiredOutput);
+  });
+
+  test('Multiple links, with 1 current', () => {
+    const path = '/example-1/';
+    const input = `
+      <sergey-link to="/example-1/">Example Link 1</sergey-link>
+      <sergey-link to="/example-2/">Example Link 2</sergey-link>
+      <sergey-link to="/example-3/">Example Link 3</sergey-link>
+      `;
+    const desiredOutput = `
+      <a href="/example-1/" class="${ACTIVE_CLASS}" aria-current="page">Example Link 1</a>
+      <a href="/example-2/">Example Link 2</a>
+      <a href="/example-3/">Example Link 3</a>
+      `;
+    const output = compileLinks(input, path);
+
+    expect(output).toBe(desiredOutput);
+  });
+
+  test('Multiple links, with 1 parent', () => {
+    const path = '/example-1/foo/index.html';
+    const input = `
+      <sergey-link to="/example-1/">Example Link 1</sergey-link>
+      <sergey-link to="/example-2/">Example Link 2</sergey-link>
+      <sergey-link to="/example-3/">Example Link 3</sergey-link>
+      `;
+    const desiredOutput = `
+      <a href="/example-1/" class="${ACTIVE_CLASS}">Example Link 1</a>
+      <a href="/example-2/">Example Link 2</a>
+      <a href="/example-3/">Example Link 3</a>
+      `;
+    const output = compileLinks(input, path);
+
+    expect(output).toBe(desiredOutput);
+  });
+
+  test('Home link, current', () => {
+    const path = '/index.html';
+    const input = `
+      <sergey-link to="/">Home</sergey-link>
+      `;
+    const desiredOutput = `
+      <a href="/" class="${ACTIVE_CLASS}" aria-current="page">Home</a>
+      `;
+    const output = compileLinks(input, path);
+
+    expect(output).toBe(desiredOutput);
+  });
+
+  test('Home link, not current', () => {
+    const path = '/about/index.html';
+    const input = `
+      <sergey-link to="/">Home</sergey-link>
+      `;
+    const desiredOutput = `
+      <a href="/" class="${ACTIVE_CLASS}">Home</a>
+      `;
+    const output = compileLinks(input, path);
+
+    expect(output).toBe(desiredOutput);
+  });
+
+  test('Link to partial, not current', () => {
+    const path = '/about/index.html';
+    const input = `
+      <sergey-link to="/#subscribe">Subscribe</sergey-link>
+      `;
+    const desiredOutput = `
+      <a href="/#subscribe" class="${ACTIVE_CLASS}">Subscribe</a>
+      `;
+    const output = compileLinks(input, path);
 
     expect(output).toBe(desiredOutput);
   });


### PR DESCRIPTION
👋 

I wanted to propose this minimal implementation, trying to keep to the spirit of Sergey, based loosely on the approach taken with Vue's `<router-link>`.

See https://router.vuejs.org/api/#router-link

I tried to also add some documentation and tests to explain why this would be useful. While the slots model works great for loads of cases, I think navigation is a major use case not currently well-served. I've been thinking of using Sergey as an introductory SSG with my design students, and active navigation states is usually the first pain point they run into when using plain old HTML.

- [x] Adds `class="active"` on links to current page and parents
- [x] Adds `aria-current="page"` on links to current page
- [x] Configurable active class with `--active-class` or `SERGEY_ACTIVE_CLASS`
- [x] Example site uses an example for its navigation
- [x] New documentation page for links on example site
- [x] Tests added and passing

If you like this idea and it's worth adding despite the additional complexity, I _might_ recommend adding support similar to `<router-link>` for adding classes on an outer element kind of like:

```vue
<router-link tag="li" to="/foo">
  <a>/foo</a>
</router-link>
```

**Known issue:** The "Links" page on the documentation/example site uses Markdown. I spent some time tracking down why the current implementation is breaking fenced code blocks, but couldn't get anywhere. I'd prefer to keep the code examples directly in the markdown files, instead of using Github gists, but if that's a better solution for now, I'm all for it.