### PR TITLE
Use CSS selector query-based instead of Regular Expressions

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,10 @@
   "dependencies": {
     "chokidar": "^2.1.5",
     "connect": "^3.6.6",
+    "css-select": "^2.1.0",
+    "domutils": "^2.0.0",
     "dotenv": "^7.0.0",
+    "htmlparser2": "^4.1.0",
     "marked": "^0.6.2",
     "serve-static": "^1.13.2"
   },

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "dotenv": "^7.0.0",
     "htmlparser2": "^4.1.0",
     "marked": "^0.6.2",
-    "serve-static": "^1.13.2"
+    "serve-static": "^1.13.2",
+    "uid": "^1.0.0"
   },
   "devDependencies": {
     "jest": "^24.7.1"

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,11 @@
 const fs = require('fs');
 const { performance } = require('perf_hooks');
 const marked = require('marked');
+const {
+  html: {
+    prepareHTML,
+  },
+} = require('./lib');
 require('dotenv').config();
 
 /**
@@ -210,7 +215,7 @@ const prepareImports = async folder => {
 };
 
 const primeImport = (path, body) => {
-  cachedImports[path] = body;
+  cachedImports[path] = path.endsWith('.html') ? prepareHTML(body) : body;
 };
 
 const getSlots = content => {
@@ -313,7 +318,8 @@ const compileImport = (body, pattern) => {
   return body;
 };
 
-const compileTemplate = (body, slots = { default: '' }) => {
+const compileTemplate = (body_, slots = { default: '' }) => {
+  let body = prepareHTML(body_);
   body = compileSlots(body, slots);
 
   if (!hasImports(body)) {

--- a/src/index.js
+++ b/src/index.js
@@ -1,12 +1,11 @@
 #!/usr/bin/env node
 const fs = require('fs');
 const { performance } = require('perf_hooks');
-const { parseDOM } = require('htmlparser2');
-const { selectAll } = require('css-select');
 const domutils = require('domutils');
 const marked = require('marked');
 const {
   html: {
+    nodes: { queryNodesByHTML },
     changeTag,
     prepareHTML,
   },
@@ -223,9 +222,11 @@ const getSlots = (content) => {
   };
 
   // Search content for templates
-  const nodes = parseDOM(content);
-  const items = selectAll(patterns.template, nodes);
-  items.forEach((node) => {
+  const { nodes } = queryNodesByHTML({
+    html: content,
+    selector: patterns.template,
+  });
+  nodes.forEach((node) => {
     const find = domutils.getOuterHTML(node);
     const name = domutils.getAttributeValue(node, 'name');
     const data = domutils.getInnerHTML(node);

--- a/src/index.js
+++ b/src/index.js
@@ -61,7 +61,7 @@ const excludedFolders = [
 
 const patterns = {
   whitespace: /^\s+|\s+$/g,
-  templates: /<sergey-template name="([a-zA-Z0-9-_.\\\/]*)">(.*?)<\/sergey-template>/gms,
+  template: 'sergey-template',
   slot: 'sergey-slot',
   import: 'sergey-import',
   link: 'sergey-link',
@@ -216,19 +216,20 @@ const primeImport = (path, body) => {
   cachedImports[path] = path.endsWith('.html') ? prepareHTML(body) : body;
 };
 
-const getSlots = content => {
+const getSlots = (content) => {
   // Extract templates first
   const slots = {
-    default: formatContent(content) || ''
+    default: formatContent(content) || '',
   };
 
   // Search content for templates
-  while ((m = patterns.templates.exec(content)) !== null) {
-    if (m.index === patterns.templates.lastIndex) {
-      patterns.templates.lastIndex++;
-    }
+  const nodes = parseDOM(content);
+  const items = selectAll(patterns.template, nodes);
+  items.forEach((node) => {
+    const find = domutils.getOuterHTML(node);
+    const name = domutils.getAttributeValue(node, 'name');
+    const data = domutils.getInnerHTML(node);
 
-    const [find, name, data] = m;
     if (name !== 'default') {
       // Remove it from the default content
       slots.default = slots.default.replace(find, '');
@@ -236,7 +237,7 @@ const getSlots = content => {
 
     // Add it as a named slot
     slots[name] = formatContent(data);
-  }
+  });
 
   slots.default = formatContent(slots.default);
 

--- a/src/lib/html/change-tag/change-items-by-html-fallback.js
+++ b/src/lib/html/change-tag/change-items-by-html-fallback.js
@@ -1,0 +1,29 @@
+const changeItemsByHTML = require('./change-items-by-html');
+
+/**
+ * bug-fix for tags inside tags (e.g. <meta foo="<sergey-slot></sergey-slot>">)
+ * Extends `changeItemsByHTML`.
+ * Can match tags inside tags 
+ * @author Gabriel Rodrigues <jipacoding@gmail.com>
+ */
+module.exports = (options) => {
+  let { html, selector } = options;
+
+  if (html.includes(`</${selector}>`)) {
+    const regexpRangeTag = selector.replace('-', '\\-');
+    const remaingTags =
+      html.match(
+        new RegExp(
+          `<${selector}[^<]*>[^<${regexpRangeTag}]*<\\/${selector}>`,
+          'g'
+        )
+      ) || [];
+
+    const foundAs = remaingTags.join('');
+    html = html.replace(
+      foundAs,
+      changeItemsByHTML(Object.assign({}, options, { html: foundAs }))
+    );
+  }
+  return html;
+};

--- a/src/lib/html/change-tag/change-items-by-html-fallback.test.js
+++ b/src/lib/html/change-tag/change-items-by-html-fallback.test.js
@@ -1,0 +1,48 @@
+const prepareHTML = require('../prepare-html');
+const { changeItemsByHTML, changeItemsByHTMLFallback } = require('./index');
+const getOptions = (option, html_) =>
+  Object.assign({}, option, { html: html_ });
+
+const options = [
+  {
+    selector: 'get-title',
+    changeItem: () => {
+      return '...';
+    },
+  },
+  {
+    selector: 'get-text',
+    changeItem: () => {
+      return 'text';
+    },
+  },
+];
+
+const input = prepareHTML(
+  '<div><p title="<get-title />"><get-text /></p></div>'
+);
+
+test('Shoud fail to match tag with changeItemsByHTML', () => {
+  const expected = prepareHTML('<div><p title="<get-title/>">text</p></div>');
+
+  let output = input;
+  output = changeItemsByHTML(getOptions(options[0], output));
+  output = changeItemsByHTML(getOptions(options[1], output));
+
+  expect(output).toBe(expected);
+});
+
+test('Change HTML tags with changeItemsByHTMLFallback', () => {
+  const expected = prepareHTML('<div><p title="...">text</p></div>');
+
+  let output = input;
+
+  // get-title
+  output = changeItemsByHTML(getOptions(options[0], output));
+  output = changeItemsByHTMLFallback(getOptions(options[0], output));
+  // get-text
+  output = changeItemsByHTML(getOptions(options[1], output));
+  output = changeItemsByHTMLFallback(getOptions(options[1], output));
+
+  expect(output).toBe(expected);
+});

--- a/src/lib/html/change-tag/change-items-by-html.js
+++ b/src/lib/html/change-tag/change-items-by-html.js
@@ -1,0 +1,32 @@
+const { parseDOM } = require('htmlparser2');
+const { selectAll } = require('css-select');
+const domutils = require('domutils');
+
+const defaultModes = {
+  innerHTML: domutils.getInnerHTML,
+  outerHTML: domutils.getOuterHTML,
+};
+
+/**
+ * Core function to change tags
+ * @author Gabriel Rodrigues <jipacoding@gmail.com>
+ */
+module.exports = ({
+  html,
+  selector,
+  changeItem,
+  mode = 'outerHTML',
+  modes = defaultModes,
+  base: base_,
+}) => {
+  let base = html || base_ || '';
+
+  const nodes = parseDOM(base);
+  const selectedNodes = selectAll(selector, nodes);
+  selectedNodes.forEach((i) => {
+    const oldContent = modes[mode](i);
+    const newContent = changeItem(i, oldContent);
+    base = base.replace(oldContent, newContent);
+  });
+  return base;
+};

--- a/src/lib/html/change-tag/change-items-by-html.js
+++ b/src/lib/html/change-tag/change-items-by-html.js
@@ -26,7 +26,10 @@ module.exports = ({
   selectedNodes.forEach((i) => {
     const oldContent = modes[mode](i);
     const newContent = changeItem(i, oldContent);
+
+    if(newContent !== false) {
     base = base.replace(oldContent, newContent);
+    }
   });
   return base;
 };

--- a/src/lib/html/change-tag/change-items-by-html.js
+++ b/src/lib/html/change-tag/change-items-by-html.js
@@ -1,6 +1,5 @@
-const { parseDOM } = require('htmlparser2');
-const { selectAll } = require('css-select');
 const domutils = require('domutils');
+const { queryNodesByHTML } = require('../nodes');
 
 const defaultModes = {
   innerHTML: domutils.getInnerHTML,
@@ -21,14 +20,13 @@ module.exports = ({
 }) => {
   let base = html || base_ || '';
 
-  const nodes = parseDOM(base);
-  const selectedNodes = selectAll(selector, nodes);
+  const { nodes: selectedNodes } = queryNodesByHTML({ html: base, selector });
   selectedNodes.forEach((i) => {
     const oldContent = modes[mode](i);
     const newContent = changeItem(i, oldContent);
 
     if(newContent !== false) {
-    base = base.replace(oldContent, newContent);
+      base = base.replace(oldContent, newContent);
     }
   });
   return base;

--- a/src/lib/html/change-tag/change-items-by-html.test.js
+++ b/src/lib/html/change-tag/change-items-by-html.test.js
@@ -1,0 +1,28 @@
+const { getInnerHTML, getOuterHTML } = require('domutils');
+const { changeItemsByHTML } = require('./index');
+
+test('Change HTML tags', () => {
+  const input =
+    '<div><p class="inner-only">KEEP INNER ONLY</p><p class="attrb" data-foo="bar">attrb</p></div>';
+  const expected =
+    '<div>KEEP INNER ONLY<p class="attrb" data-foo="baz">attrb</p></div>';
+
+  let output = input;
+  output = changeItemsByHTML({
+    html: output,
+    selector: '.inner-only',
+    changeItem: (node) => {
+      return getInnerHTML(node);
+    },
+  });
+  output = changeItemsByHTML({
+    html: output,
+    selector: '.attrb',
+    changeItem: (node) => {
+      node.attribs['data-foo'] = 'baz';
+      return getOuterHTML(node);
+    },
+  });
+
+  expect(output).toBe(expected);
+});

--- a/src/lib/html/change-tag/index.js
+++ b/src/lib/html/change-tag/index.js
@@ -1,2 +1,5 @@
 const changeItemsByHTML = require('./change-items-by-html');
+const changeItemsByHTMLFallback = require('./change-items-by-html-fallback');
 module.exports = { changeItemsByHTML };
+
+module.exports = { changeItemsByHTML, changeItemsByHTMLFallback };

--- a/src/lib/html/change-tag/index.js
+++ b/src/lib/html/change-tag/index.js
@@ -1,5 +1,12 @@
+const uid = require('uid');
+const domutils = require('domutils');
 const changeItemsByHTML = require('./change-items-by-html');
 const changeItemsByHTMLFallback = require('./change-items-by-html-fallback');
+
+const returnModes = {
+  outerHTML: domutils.getOuterHTML,
+  innerHTML: domutils.getInnerHTML,
+};
 
 /**
  * @author Gabriel Rodrigues <jipacoding@gmail.com>
@@ -8,12 +15,21 @@ function main(options, fn) {
   const { html: html_, selector, mode = 'outerHTML' } = options;
   let html = html_;
 
-  const changeItem = (i) => fn(i);
+  const changeItemNodeId = `sergey-node_id-${uid(6)}`;
+  const changeItem = (node, ...args) => {
+    if (typeof node.attribs[changeItemNodeId] === 'undefined') {
+      node.attribs[changeItemNodeId] = '';
+      return fn(node, ...args);
+    }
+    return false;
+  };
+
   html = changeItemsByHTML(Object.assign({}, options, { html, changeItem }));
   html = changeItemsByHTMLFallback(
     Object.assign({}, options, { html, changeItem })
   );
 
+  html = html.replace(new RegExp(` ?${changeItemNodeId}`, 'g'), '');
   return html;
 }
 

--- a/src/lib/html/change-tag/index.js
+++ b/src/lib/html/change-tag/index.js
@@ -1,0 +1,2 @@
+const changeItemsByHTML = require('./change-items-by-html');
+module.exports = { changeItemsByHTML };

--- a/src/lib/html/change-tag/index.js
+++ b/src/lib/html/change-tag/index.js
@@ -1,5 +1,20 @@
 const changeItemsByHTML = require('./change-items-by-html');
 const changeItemsByHTMLFallback = require('./change-items-by-html-fallback');
-module.exports = { changeItemsByHTML };
 
-module.exports = { changeItemsByHTML, changeItemsByHTMLFallback };
+/**
+ * @author Gabriel Rodrigues <jipacoding@gmail.com>
+ */
+function main(options, fn) {
+  const { html: html_, selector, mode = 'outerHTML' } = options;
+  let html = html_;
+
+  const changeItem = (i) => fn(i);
+  html = changeItemsByHTML(Object.assign({}, options, { html, changeItem }));
+  html = changeItemsByHTMLFallback(
+    Object.assign({}, options, { html, changeItem })
+  );
+
+  return html;
+}
+
+module.exports = { main, changeItemsByHTML, changeItemsByHTMLFallback };

--- a/src/lib/html/change-tag/index.test.js
+++ b/src/lib/html/change-tag/index.test.js
@@ -1,0 +1,20 @@
+const { getInnerHTML, getOuterHTML } = require('domutils');
+const changeTag = require('./index');
+
+test('Change HTML tags', () => {
+  const input =
+    '<div><p class="inner-only">KEEP INNER ONLY</p><p class="attrb" data-foo="bar">attrb</p></div>';
+  const expected =
+    '<div>KEEP INNER ONLY<p class="attrb" data-foo="baz">attrb</p></div>';
+
+  let output = input;
+  output = changeTag.main({ html: output, selector: '.inner-only' }, (node) => {
+    return getInnerHTML(node);
+  });
+  output = changeTag.main({ html: output, selector: '.attrb' }, (node) => {
+    node.attribs['data-foo'] = 'baz';
+    return getOuterHTML(node);
+  });
+
+  expect(output).toBe(expected);
+});

--- a/src/lib/html/index.js
+++ b/src/lib/html/index.js
@@ -1,7 +1,9 @@
+const nodes = require('./nodes');
 const changeTag = require('./change-tag');
 const prepareHTML = require('./prepare-html');
 
 module.exports = {
+  nodes,
   changeTag,
-  prepareHTML
+  prepareHTML,
 };

--- a/src/lib/html/index.js
+++ b/src/lib/html/index.js
@@ -1,0 +1,5 @@
+const prepareHTML = require('./prepare-html');
+
+module.exports = {
+  prepareHTML
+};

--- a/src/lib/html/index.js
+++ b/src/lib/html/index.js
@@ -1,5 +1,7 @@
+const changeTag = require('./change-tag');
 const prepareHTML = require('./prepare-html');
 
 module.exports = {
+  changeTag,
   prepareHTML
 };

--- a/src/lib/html/nodes/get-nodes.js
+++ b/src/lib/html/nodes/get-nodes.js
@@ -1,0 +1,5 @@
+const { parseDOM } = require('htmlparser2');
+
+const getNodes = ({ html }) => parseDOM(html);
+
+module.exports = getNodes;

--- a/src/lib/html/nodes/get-nodes.test.js
+++ b/src/lib/html/nodes/get-nodes.test.js
@@ -1,0 +1,18 @@
+const { getNodes } = require('./index');
+const { getOuterHTML } = require('domutils');
+
+test('Return HTML (XML) nodes', () => {
+  const input = '<div>first</div><p>second</p>';
+  const output = getNodes({ html: input }).length;
+  const expected = 2;
+
+  expect(output).toBe(expected);
+});
+
+test('Return HTML (XML) nodes', () => {
+  const input = '<div>first</div><p>second</p>';
+  const output = getOuterHTML(getNodes({ html: input }));
+  const expected = input;
+
+  expect(output).toBe(expected);
+});

--- a/src/lib/html/nodes/index.js
+++ b/src/lib/html/nodes/index.js
@@ -1,0 +1,9 @@
+const getNodes = require('./get-nodes');
+const queryNodes = require('./query-nodes');
+const queryNodesByHTML = require('./query-nodes-by-html');
+
+module.exports = {
+  getNodes,
+  queryNodes,
+  queryNodesByHTML,
+};

--- a/src/lib/html/nodes/query-nodes-by-html.js
+++ b/src/lib/html/nodes/query-nodes-by-html.js
@@ -1,0 +1,14 @@
+const getNodes = require('./get-nodes');
+const queryNodes = require('./query-nodes');
+
+const queryNodesByHTML = ({ html, selector }) => {
+  const rootNodes = getNodes({ html });
+  const nodes = queryNodes({ nodes: rootNodes, selector });
+
+  return {
+    rootNodes,
+    nodes,
+  };
+};
+
+module.exports = queryNodesByHTML;

--- a/src/lib/html/nodes/query-nodes-by-html.test.js
+++ b/src/lib/html/nodes/query-nodes-by-html.test.js
@@ -1,0 +1,9 @@
+const queryNodesByHTML = require('./query-nodes-by-html');
+
+test('Get nodes from select query by using HTML', () => {
+  const input = '<div>first <div>second</div> first</div><div>third</div>';
+  const output = queryNodesByHTML({ html: input, selector: 'div' }).nodes.length;
+  const expected = 3;
+
+  expect(output).toBe(expected);
+});

--- a/src/lib/html/nodes/query-nodes.js
+++ b/src/lib/html/nodes/query-nodes.js
@@ -1,0 +1,5 @@
+const { selectAll } = require('css-select');
+
+const queryNodes = ({ nodes, selector }) => selectAll(selector, nodes);
+
+module.exports = queryNodes;

--- a/src/lib/html/nodes/query-nodes.test.js
+++ b/src/lib/html/nodes/query-nodes.test.js
@@ -1,0 +1,11 @@
+const queryNodes = require('./query-nodes');
+const getNodes = require('./get-nodes');
+
+test('Get nodes from select query', () => {
+  const input = '<div>first <div>second</div> first</div><div>third</div>';
+  const nodes = getNodes({ html: input });
+  const output = queryNodes({ nodes, selector: 'div' }).length;
+  const expected = 3;
+
+  expect(output).toBe(expected);
+});

--- a/src/lib/html/prepare-html.js
+++ b/src/lib/html/prepare-html.js
@@ -1,0 +1,27 @@
+const VOID_ELEMENTS = require('./voidelements.json');
+
+// `<sergey-slot ...args />` -> `<sergey-slot ...args></sergey-slot>`
+// the function ignores void elements like `<img />`
+module.exports = (html_) => {
+  let html = html_ || '';
+  if (!html.trim()) return html;
+
+  (html.match(/<[^<|\/>]+\/>/g) || [])
+    .map((original) => {
+      const def = original.slice(1, -2).trim();
+      const tagName = def.split(' ')[0].trim();
+
+      return { original, def, tagName };
+    })
+    .forEach(({ original, def, tagName }) => {
+      let newTagContent = def;
+
+      newTagContent = VOID_ELEMENTS.includes(tagName)
+        ? `<${newTagContent.replace(/[\r|\n]/g, '')}>`
+        : `<${newTagContent}></${tagName}>`;
+
+      html = html.replace(original, newTagContent);
+    });
+
+  return html;
+};

--- a/src/lib/html/prepare-html.js
+++ b/src/lib/html/prepare-html.js
@@ -1,3 +1,5 @@
+const { parseDOM } = require('htmlparser2');
+const { getOuterHTML } = require('domutils');
 const VOID_ELEMENTS = require('./voidelements.json');
 
 // `<sergey-slot ...args />` -> `<sergey-slot ...args></sergey-slot>`
@@ -23,5 +25,6 @@ module.exports = (html_) => {
       html = html.replace(original, newTagContent);
     });
 
+  html = getOuterHTML(parseDOM(html));
   return html;
 };

--- a/src/lib/html/prepare-html.js
+++ b/src/lib/html/prepare-html.js
@@ -1,4 +1,4 @@
-const { parseDOM } = require('htmlparser2');
+const { getNodes } = require('./nodes');
 const { getOuterHTML } = require('domutils');
 const VOID_ELEMENTS = require('./voidelements.json');
 
@@ -25,6 +25,6 @@ module.exports = (html_) => {
       html = html.replace(original, newTagContent);
     });
 
-  html = getOuterHTML(parseDOM(html));
+  html = getOuterHTML(getNodes({ html }));
   return html;
 };

--- a/src/lib/html/prepare-html.test.js
+++ b/src/lib/html/prepare-html.test.js
@@ -7,3 +7,16 @@ test('Prepare HTML for self-closing tags', () => {
 
   expect(output).toBe(expected);
 });
+
+
+test('Prepare HTML for multiline tags', () => {
+  const input = `<div
+foo="bar"
+>...</div>`;
+
+  const expected = '<div foo="bar">...</div>';
+  const output = prepareHTML(input);
+
+  expect(output).toBe(expected);
+});
+

--- a/src/lib/html/prepare-html.test.js
+++ b/src/lib/html/prepare-html.test.js
@@ -1,0 +1,9 @@
+const { prepareHTML } = require('./index');
+
+test('Prepare HTML for self-closing tags', () => {
+  const input = '<div><sergey-slot /><img></div>';
+  const expected = '<div><sergey-slot></sergey-slot><img></div>';
+  const output = prepareHTML(input);
+
+  expect(output).toBe(expected);
+});

--- a/src/lib/html/voidelements.json
+++ b/src/lib/html/voidelements.json
@@ -1,0 +1,16 @@
+[
+  "area",
+  "base",
+  "br",
+  "col",
+  "embed",
+  "hr",
+  "img",
+  "input",
+  "link",
+  "meta",
+  "param",
+  "source",
+  "track",
+  "wbr"
+]

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -1,0 +1,3 @@
+const html = require('./html');
+
+module.exports = { html };


### PR DESCRIPTION
Query and change HTML tags with [CSS Selectors](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Selectors) using the modules  [CSSselect](https://www.npmjs.com/package/css-select), [htmlparser2](https://www.npmjs.com/package/htmlparser2) and [domutils](https://www.npmjs.com/package/domutils). The sergey's source code uses a lot of `while` loops and Regular Expressions. This proposal can handle html tags by querying with [CSSselect](https://www.npmjs.com/package/css-select) and making a DOM-based changes with [domutils](https://www.npmjs.com/package/domutils).

Before was:

```js
while ((m = patterns.templates.exec(content)) !== null) {
  if (m.index === patterns.templates.lastIndex) {
    patterns.templates.lastIndex++;
  }
  const [find, name, data] = m;
  if (name !== "default") {
    slots.default = slots.default.replace(find, "");
  }
  slots[name] = formatContent(data);
}
```

Now can be:

```js
const { nodes } = queryNodesByHTML({
  html: content,
  selector: patterns.template,
});
nodes.forEach((node) => {
  const find = domutils.getOuterHTML(node);
  const name = domutils.getAttributeValue(node, "name");
  const data = domutils.getInnerHTML(node);

  if (name !== "default") {
    slots.default = slots.default.replace(find, "");
  }
  slots[name] = formatContent(data);
});
```
----

Some implemented functions:

- `html/prepare-html`

  Prepare and format HTML code to be used later. 

  For example, parse `<sergey-slot />` to  `<sergey-slot ...args></sergey-slot>`

- `html/change-tag`

  - `changeItemsByHTML`
    ```js
    changeItemsByHTML({
      html: "<p></p>",
      selector: "p",
      changeItem: (node: Node) => {
        node.atttribs.class = "foo";
        return domutils.getOuterHTML(node);
      }
    })
    ```

    Output: `<p class="foo"></p>`

  - `changeItemsByHTMLFallback`

    The same implementation of `changeItemsByHTML` but works with tags inside tags (e.g.  `<a title="<some-getter />">text</a>`)
   
  - `main`
  
    Applies `changeItemsByHTML` and `changeItemsByHTMLFallback` (runs once `changeItem` for the selected nodes).

----

Maybe related with #36 #24