### PR TITLE
Add --host option, default to localhost

### DIFF
--- a/example/_imports/options.md
+++ b/example/_imports/options.md
@@ -51,3 +51,10 @@ When in dev mode, Sergey watches for file changes, but ignores common folders li
 **Env:** `SERGEY_PORT`
 
 Override the default port of 8080 with this option.
+
+---
+
+**Arg:** `--host=`  
+**Env:** `SERGEY_HOST`
+
+Override the default host of `localhost` with this option.

--- a/src/index.js
+++ b/src/index.js
@@ -17,6 +17,7 @@ const isWatching = process.argv.includes('--watch');
 
 const ROOT = getEnv('--root=', 'SERGEY_ROOT') || './';
 const PORT = Number(getEnv('--port=', 'SERGEY_PORT')) || 8080;
+const HOST = getEnv('--host=', 'SERGEY_HOST') || 'localhost';
 
 const IMPORTS_LOCAL = getEnv('--imports=', 'SERGEY_IMPORTS') || '_imports';
 const IMPORTS = `${ROOT}${IMPORTS_LOCAL}/`;
@@ -503,8 +504,8 @@ const sergeyRuntime = async () => {
 
     connect()
       .use(serveStatic(OUTPUT))
-      .listen(PORT, function() {
-        console.log(`Sergey running on http://localhost:${PORT}`);
+      .listen(PORT, HOST, function() {
+        console.log(`Sergey running on http://${HOST}:${PORT}`);
       });
   }
 };


### PR DESCRIPTION
I added an option, `--host`, and default to `localhost`. Tested using `npm test` and also by running `node index.js --watch --root=./example/ --host=0.0.0.0` and `node index.js --watch --root=./example/` to compare whether I could access on another computer.