### PR TITLE
Add HTML extensions to serverStatic

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -502,7 +502,7 @@ const sergeyRuntime = async () => {
     watcher.on('unlink', task);
 
     connect()
-      .use(serveStatic(OUTPUT))
+      .use(serveStatic(OUTPUT, {extensions: ['html', 'htm']}))
       .listen(PORT, function() {
         console.log(`Sergey running on http://localhost:${PORT}`);
       });


### PR DESCRIPTION
Adding HTML extensions to `serverStatic` would allow using links to pages without specifying extensions (clean URLs). [^1] 

Currently, the server does not look up HTML files and returns HTTP error 404. For example, if I have file `example.html` I can't link to it as `/example`. 

In production, this can be configured per server. But this feature would be useful for local development to avoid using 3-rd party `serve` package.

[^1]: https://github.com/expressjs/serve-static#extensions